### PR TITLE
Docs: FIx wrong arguments of set-up-ssh

### DIFF
--- a/doc/github-deploy-keys.md
+++ b/doc/github-deploy-keys.md
@@ -130,8 +130,8 @@ Add the necessary commands to the `.travis.yml` file, and either:
   after_success:
     - |
 
-         $(npm bin)/set-up-ssh --key "$encrypted_XXXXXXXXXXXX_key" \
-                               --iv "$encrypted_XXXXXXXXXXXX_iv" \
+         $(npm bin)/set-up-ssh -k "$encrypted_XXXXXXXXXXXX_key" \
+                               -iv "$encrypted_XXXXXXXXXXXX_iv" \
                                --path-encrypted-key ".travis/github_deploy_key.enc"
   ```
 


### PR DESCRIPTION
Correct arguments of `$(npm bin)/set-up-ssh`

`--key` => `-k`
`--iv` => `-iv`